### PR TITLE
Fix optional boolean behavior

### DIFF
--- a/lib/reasonable/value.rb
+++ b/lib/reasonable/value.rb
@@ -17,7 +17,7 @@ module Reasonable
       self.class.send(:config).each do |name, config|
         options = config[:options]
         if options[:optional]
-          attributes[name] ||= options[:default]
+          attributes[name] = options[:default] if attributes[name].nil?
           next if attributes[name].nil?
         end
 

--- a/spec/reasonable/value_spec.rb
+++ b/spec/reasonable/value_spec.rb
@@ -46,6 +46,7 @@ class OptionalValueWithDefault < Reasonable::Value
 
   attribute :integer, Integer, optional: true, default: 1
   attribute :string, String, optional: true, default: 'foo'
+  attribute :boolean, [TrueClass, FalseClass], optional: true, default: true
 
 end
 
@@ -121,6 +122,10 @@ RSpec.describe Reasonable::Value do
         to eq('foo')
       expect(OptionalValueWithDefault.new(string: nil).string).
         to eq('foo')
+      expect(OptionalValueWithDefault.new(boolean: nil).boolean).
+        to eq(true)
+      expect(OptionalValueWithDefault.new(boolean: false).boolean).
+        to eq(false)
     end
 
     it 'ignores undefined attributes' do


### PR DESCRIPTION
Given the following declaration

``` ruby
class Value < Reasonable::Value
  attribute :boolean, [TrueClass, FalseClass], optional: true, default: true
end
```

Before: Value.new(boolean: false).boolean => true
After: Value.new(boolean: false).boolean => false

Fix #13 